### PR TITLE
Add default vendor/vendor.json file

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,7 @@
+{
+    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
+    "rootPath": "github.com/sendwithus/battlesnake-go",
+    "heroku": {
+        "sync": false
+    }
+}


### PR DESCRIPTION
Without this, or another dependency system's artifacts, Heroku doesn't know that this is a Go application.

For more information:

https://github.com/heroku/heroku-buildpack-go#usage-with-other-vendoring-systems

    $ git push heroku master
    Counting objects: 98, done.
    Delta compression using up to 4 threads.
    Compressing objects: 100% (49/49), done.
    Writing objects: 100% (98/98), 1.56 MiB | 666.00 KiB/s, done.
    Total 98 (delta 41), reused 98 (delta 41)
    remote: Compressing source files... done.
    remote: Building source:
    remote:
    remote:  !     No default language could be detected for this app.
    remote: 			HINT: This occurs when Heroku cannot detect the buildpack to use for this application automatically.
    remote: 			See https://devcenter.heroku.com/articles/buildpacks
    remote:
    remote:  !     Push failed
    remote: Verifying deploy...
    remote:
    remote: !	Push rejected to desolate-thicket-58352.
    remote: